### PR TITLE
Disable base no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ module.exports = {
     ],
 
     // Covered by the tsc compiler (noUnusedLocals)
+    'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
 
     // Prevent bugs, not styling


### PR DESCRIPTION
### Why
The current configuration can report unused variables incorrectly in some cases.

For example, the `callbackArg` param in the function type expression below is reported as unused
```typescript
// error  'callbackArg' is defined but never used  (no-unused-vars)
export function callTwice<A>(fn: (callbackArg: A) => void, arg: A): void {
  fn(arg)
  fn(arg)
}
```

### Fix
We are already disabling the corresponding `@typescript-eslint/no-unused-vars` rule, deferring detection of unused vars to the tsc compiler instead.

This small change also turns off the base rule.

### Testing
[This demo branch](https://github.com/exercism/eslint-config-typescript/compare/main...solebared:recreate-no-used-vars-false-positive-on-function-type-expr) demonstrates the issue. Uncommenting the suggested change resolves the issue.

### Reference
https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-vars.md

### Questions
* I'm relatively new to typescript and exercism, so not familiar with the constellation of configurations that come together on a given exercise. If there's a better place to address this, pls let me know.
* I was surprised that this issue doesn't surface more frequently. I'm guessing this is partly because `lint:ci` is not run when `yarn test` is invoked? The name implies that it's run during CI, but i also didn't see any `eslint` errors on one of my submitted solutions.